### PR TITLE
Twitter Repetition error removed

### DIFF
--- a/app/workers/twitter_search.rb
+++ b/app/workers/twitter_search.rb
@@ -4,7 +4,13 @@ class TwitterSearch
 
   def perform
     twitter_client.search("@denunci_AR", result_type: "recent").collect do |tweet|
-      Complaint.create!(user: tweet.user.name, user_id: tweet.user.id, tweet_id: tweet.id, text: tweet.text, rating: 0, complained_at: tweet.created_at)
+      begin
+        Complaint.create!(user: tweet.user.name, user_id: tweet.user.id, tweet_id: tweet.id, text: tweet.text, rating: 0, complained_at: tweet.created_at)
+      rescue ActiveRecord::RecordInvalid => invalid
+        logger.error(
+          "User: #{tweet.user.name} - Tweet ID: #{tweet.id} - Text: #{tweet.text} - Error: #{invalid.record.errors}"
+        )
+end
     end
   end
 


### PR DESCRIPTION
## Summary

No longer throwing an uncaught exception when a tweet is repeated. Instead, the error is logged.
## Trello Card

https://trello.com/c/z1CxGwk0/37-evitar-problemas-con-tweets-repetidos
