### PR TITLE
Set up the Twitter query to only search latest tweets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,9 @@ gem 'chosen-rails'
 
 gem 'twitter'
 
+# Key value preference storage in ActiveRecord
+gem 'rails-settings-cached'
+
 group :development do
   # Gem to detect N+1 queries
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,8 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-settings-cached (0.6.4)
+      rails (>= 4.2.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -474,6 +476,7 @@ DEPENDENCIES
   pry-rails
   pundit
   rails (= 4.2.6)
+  rails-settings-cached
   rails_12factor
   ransack
   recipient_interceptor
@@ -506,4 +509,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.3
+   1.12.4

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,5 @@
+# RailsSettings Model
+class Setting < RailsSettings::Base
+  source Rails.root.join("config/app.yml")
+  namespace Rails.env
+end

--- a/config/app.yml
+++ b/config/app.yml
@@ -1,0 +1,13 @@
+# config/app.yml for rails-settings-cached
+defaults: &defaults
+  foo: "Foo"
+  bar: 123
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/db/migrate/20160525175237_create_settings.rb
+++ b/db/migrate/20160525175237_create_settings.rb
@@ -1,0 +1,17 @@
+class CreateSettings < ActiveRecord::Migration
+  def self.up
+    create_table :settings do |t|
+      t.string  :var,        null: false
+      t.text    :value,      null: true
+      t.integer :thing_id,   null: true
+      t.string  :thing_type, null: true, limit: 30
+      t.timestamps
+    end
+
+    add_index :settings, %i(thing_type thing_id var), unique: true
+  end
+
+  def self.down
+    drop_table :settings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160522032451) do
+ActiveRecord::Schema.define(version: 20160525175237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,5 +26,16 @@ ActiveRecord::Schema.define(version: 20160522032451) do
     t.text     "text"
     t.datetime "complained_at"
   end
+
+  create_table "settings", force: :cascade do |t|
+    t.string   "var",                   null: false
+    t.text     "value"
+    t.integer  "thing_id"
+    t.string   "thing_type", limit: 30
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "settings", ["thing_type", "thing_id", "var"], name: "index_settings_on_thing_type_and_thing_id_and_var", unique: true, using: :btree
 
 end


### PR DESCRIPTION
## Summary

Twitter query now saves latest tweet id processed, so future queries now query only from that point onwards
## Trello Card

https://trello.com/c/2lelSoLc/36-hacer-query-de-tweets-unicamente-a-partir-de-la-ultima-instancia-de-query
